### PR TITLE
[ISSUE-6]  Added backwards compatibility for pyrax 1.9.8 clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: python
 python:
   - "2.6"
   - "2.7"
-install: "pip install flake8"
+install: "pip install flake8==2.6.0"
 script: flake8 *.py

--- a/os_virtual_interfacesv2_python_novaclient_ext.py
+++ b/os_virtual_interfacesv2_python_novaclient_ext.py
@@ -14,6 +14,12 @@
 
 from novaclient import base
 from novaclient import utils
+# pyrax consumers will have an older version of novaclient installed
+# so we have to make sure that the 'arg' decorator is supported
+# and available
+if not hasattr(utils, 'arg'):
+    del utils
+    from novaclient.openstack.common import cliutils as utils
 
 
 class VirtualInterface(base.Resource):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name='os_virtual_interfacesv2_python_novaclient_ext',
-    version='0.20',
+    version='0.21',
     description='Adds Virtual Interfaces support to python-novaclient',
     long_description=open('README.rst').read(),
     author='Rackspace',


### PR DESCRIPTION
* includes a version for flake8 because version 3.0.4 does not work with python 2.6